### PR TITLE
Tarea 6. Creadas relaciones entre las clases Scale, Repair, ReceiptItem y Recipt

### DIFF
--- a/src/AppForSEII2526.API/Models/Receipt.cs
+++ b/src/AppForSEII2526.API/Models/Receipt.cs
@@ -2,7 +2,7 @@
 {
     public class Receipt
     {
-        
+        [Key]
         [Required]
         public int Id { get; set; }
         [Required]
@@ -16,8 +16,10 @@
         public DateTime ReceiptDate { get; set; }
         [Required]
         public double TotalPrice { get; set; }
-
-        public Receipt() { }
+        public IList<ReceiptItem> ReceiptItems { get; set; }
+        public Receipt() {
+            ReceiptItems = new List<ReceiptItem>();
+        }
         public Receipt(int id, string customerNameSurname, string deliveryAddress, PaymentMethodTypes paymentMethod, DateTime receiptDate, double totalPrice)
         {
             this.Id = id;

--- a/src/AppForSEII2526.API/Models/ReceiptItem.cs
+++ b/src/AppForSEII2526.API/Models/ReceiptItem.cs
@@ -1,28 +1,30 @@
 ﻿namespace AppForSEII2526.API.Models
 {
-    public class ReceiptIteam
+    [PrimaryKey(nameof(RepairId), nameof(ReceiptId))]
+    public class ReceiptItem
     {
-        [Key]
         [Required]
         public string Model { get; set; }
+        public Repair Repair { get; set; }
         [Required]
-        [ForeignKey("Repair")]
         public int RepairId { get; set; }
+        public Receipt Receipt { get; set; }
         [Required]
-        [ForeignKey("Receipt")]
         public int ReceiptId { get; set; }
 
-        public ReceiptIteam() { }
-        public ReceiptIteam(string model, int repairId, int receiptId)
+        public ReceiptItem() { }
+        public ReceiptItem(string model, Repair repair, Receipt receipt)
         {
             this.Model = model;
-            this.RepairId = repairId;
-            this.ReceiptId = receiptId;
+            this.Repair = repair;
+            this.RepairId = repair.Id;
+            this.Receipt = receipt;
+            this.ReceiptId = receipt.Id;
         }
 
         public override bool Equals(object obj)
         {
-            if (obj is ReceiptIteam receiptIteam)
+            if (obj is ReceiptItem receiptIteam)
             {
                 return Model == receiptIteam.Model && RepairId == receiptIteam.RepairId && ReceiptId == receiptIteam.ReceiptId;
             }

--- a/src/AppForSEII2526.API/Models/Repair.cs
+++ b/src/AppForSEII2526.API/Models/Repair.cs
@@ -11,7 +11,6 @@
         [Required]
         public string Name { get; set; }
         [Required]
-        [ForeignKey("Scale")]
         public int ScaleId { get; set; }
 
         public Repair() { }
@@ -25,6 +24,9 @@
             this.ScaleId = scaleId;
         }
 
+        //Relaciones entre clases
+        public Scale Scale { get; set; }
+        public IList<ReceiptItem> ReceiptItems { get; set; }
         public override bool Equals(object? obj)
         {
             if (obj is Repair repair)

--- a/src/AppForSEII2526.API/Models/Scale.cs
+++ b/src/AppForSEII2526.API/Models/Scale.cs
@@ -27,5 +27,9 @@
         {
             return HashCode.Combine(Id, Name);
         }
-    }
+
+        //Relaciones entre clases
+        public IList<Repair> Repairs { get; set; }
+
+        }
 }


### PR DESCRIPTION
Se añade la propiedad `ReceiptItems` a la clase `Receipt` y se corrige el nombre de `ReceiptIteam` a `ReceiptItem`. Se implementan propiedades de navegación en `ReceiptItem`, eliminando las claves foráneas. Se ajusta el constructor de `ReceiptItem` para aceptar objetos `Repair` y `Receipt`. En `Repair`, se añade una propiedad de navegación `Scale` y se elimina `ScaleId`. Finalmente, se establece una lista de `Repairs` en la clase `Scale`.