### PR TITLE
Desarrollar pruebas funcionales post

### DIFF
--- a/src/AppForSEII2526.Web/Components/Pages/Receipt/PostReceipt.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Receipt/PostReceipt.razor
@@ -116,6 +116,17 @@
 
     private void OpenDialog()
     {
+        bool hayErrores = receipt.ReceiptItems.Any(item => string.IsNullOrWhiteSpace(item.Model));
+
+        if (hayErrores)
+        {
+            // 3. Si hay error, configuramos el mensaje para que salga ARRIBA
+            messageError = "The Model field is required.";
+
+            // Importante: Hacemos return para que NO se abra el diálogo
+            return;
+        }
+
         DialogIsOpen = true;
     }
 

--- a/src/AppForSEII2526.Web/OpenAPIs/swagger4.json
+++ b/src/AppForSEII2526.Web/OpenAPIs/swagger4.json
@@ -908,6 +908,7 @@
       "ReceiptForCreateDTO": {
         "required": [
           "paymentMethod",
+          "userdeliveryaddress",
           "username",
           "usersurname"
         ],
@@ -923,9 +924,9 @@
             "type": "string"
           },
           "userdeliveryaddress": {
+            "minLength": 1,
             "type": "string",
-            "format": "multiline",
-            "nullable": true
+            "format": "multiline"
           },
           "paymentMethod": {
             "$ref": "#/components/schemas/PaymentMethodTypes"
@@ -941,6 +942,9 @@
         "additionalProperties": false
       },
       "ReceiptItemDTO": {
+        "required": [
+          "model"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -956,8 +960,8 @@
             "format": "double"
           },
           "model": {
-            "type": "string",
-            "nullable": true
+            "minLength": 1,
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/test/AppForSEII2526.UIT/CU-PurchaseDevices/UC_PurchaseMovies_UIT.cs
+++ b/test/AppForSEII2526.UIT/CU-PurchaseDevices/UC_PurchaseMovies_UIT.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
-using AppForMovies.UIT.Shared;
+using AppForSEII2526.UIT.Shared;
 using AppForSEII2526.UIT.Shared;
 
 namespace AppForSEII2526.UIT.CU_PurchaseDevices

--- a/test/AppForSEII2526.UIT/Shared/UC_UIT.cs
+++ b/test/AppForSEII2526.UIT/Shared/UC_UIT.cs
@@ -3,15 +3,15 @@ using OpenQA.Selenium.Edge;
 using OpenQA.Selenium.Firefox;
 
 
-namespace AppForMovies.UIT.Shared {
+namespace AppForSEII2526.UIT.Shared {
     public class UC_UIT : IDisposable {
 
         private bool _pipeline = false;
 
         //establish which browser you would like to use
-        private string _browser = "Chrome";
+        //private string _browser = "Chrome";
         //private string _browser = "Firefox";
-        //private string _browser = "Edge";
+        private string _browser = "Edge";
 
         protected IWebDriver _driver;
         protected readonly ITestOutputHelper _output;

--- a/test/AppForSEII2526.UIT/UC_Receipt/PostRepairs_PO.cs
+++ b/test/AppForSEII2526.UIT/UC_Receipt/PostRepairs_PO.cs
@@ -36,13 +36,16 @@ namespace AppForSEII2526.UIT.UC_Receipt
         }
 
         public void FillInModelInfo(string model, string name) {
-            WaitForBeingClickable(By.Id("RepairData_"+name));
-            _driver.FindElement(By.Id("RepairData_" + name)).Clear();
-            _driver.FindElement(By.Id("RepairData_" + name)).SendKeys(model);
+            WaitForBeingClickable(By.Id("model_"+name));
+            _driver.FindElement(By.Id("model_" + name)).Clear();
+            _driver.FindElement(By.Id("model_" + name)).SendKeys(model);
         }
 
         public void PressSubmitReceipt() { 
             _driver.FindElement(By.Id("Submit")).Click();
+            Thread.Sleep(1000);
+
+            _driver.FindElement(By.Id("Button_DialogOK")).Click();
         }
         
         public void PressModifyReceipt()
@@ -51,7 +54,7 @@ namespace AppForSEII2526.UIT.UC_Receipt
         }
 
         public bool CheckListOfReceiptItems(List<string[]> expectedReceiptItems, string model, string name) {
-            return CheckBodyTable(expectedReceiptItems, By.Id("TableOfReceiptItems")) && _driver.FindElement(By.Id("RepairData_" + name)).GetAttribute("value") == model;
+            return CheckBodyTable(expectedReceiptItems, By.Id("TableOfReceiptItems")) && _driver.FindElement(By.Id("model_" + name)).GetAttribute("value") == model;
         }
 
         public bool CheckValidationError(string expectedError) {

--- a/test/AppForSEII2526.UIT/UC_Receipt/PostRepairs_PO.cs
+++ b/test/AppForSEII2526.UIT/UC_Receipt/PostRepairs_PO.cs
@@ -43,9 +43,6 @@ namespace AppForSEII2526.UIT.UC_Receipt
 
         public void PressSubmitReceipt() { 
             _driver.FindElement(By.Id("Submit")).Click();
-            Thread.Sleep(1000);
-
-            _driver.FindElement(By.Id("Button_DialogOK")).Click();
         }
         
         public void PressModifyReceipt()
@@ -54,7 +51,11 @@ namespace AppForSEII2526.UIT.UC_Receipt
         }
 
         public bool CheckListOfReceiptItems(List<string[]> expectedReceiptItems, string model, string name) {
-            return CheckBodyTable(expectedReceiptItems, By.Id("TableOfReceiptItems")) && _driver.FindElement(By.Id("model_" + name)).GetAttribute("value") == model;
+            var result = true;
+            result = result && CheckBodyTable(expectedReceiptItems, By.Id("TableOfReceiptItems"));
+            result = result && _driver.FindElement(By.Id("model_" + name)).GetAttribute("value") == model;
+
+            return result;
         }
 
         public bool CheckValidationError(string expectedError) {

--- a/test/AppForSEII2526.UIT/UC_Receipt/SelectRepairs_PO.cs
+++ b/test/AppForSEII2526.UIT/UC_Receipt/SelectRepairs_PO.cs
@@ -14,7 +14,7 @@ namespace AppForSEII2526.UIT.UC_Receipt
         By RepairButton = By.Id("RepairButton");
         By tableOfRepairsBy = By.Id("TableofRepairs");
         public SelectRepairs_PO(IWebDriver driver, ITestOutputHelper output) : base(driver, output) { }
-        public void SearchMovies(string name, string scale) {
+        public void SearchRepairs(string name, string scale) {
             WaitForBeingClickable(inputName);
             _driver.FindElement(inputName).SendKeys(name);
             

--- a/test/AppForSEII2526.UIT/UC_Receipt/UC_Receipts_UIT.cs
+++ b/test/AppForSEII2526.UIT/UC_Receipt/UC_Receipts_UIT.cs
@@ -46,15 +46,15 @@ namespace AppForSEII2526.UIT.UC_Receipt
             postRepairs_PO = new PostRepairs_PO(_driver, output);
             detailsRepairs_PO = new DetailsRepairs_PO(_driver, output);
         }
-        /* Como no va aún el login lo dejo comentado 
+         
         private void Precondition_perform_login() {
             Perform_login("rdiaz@example.com", "Password123!");
         }
-        */
+        
         private void InitialStepsForReceiptUC()
         {
             Initial_step_opening_the_web_page();
-            //Precondition_perform_login();
+            Precondition_perform_login();
             selectRepairs_PO.WaitForBeingVisible(By.Id("CreateReceipt"));
             _driver.FindElement(By.Id("CreateReceipt")).Click();
         }
@@ -86,7 +86,7 @@ namespace AppForSEII2526.UIT.UC_Receipt
 
         }
         [Fact]
-        [Trait("Level Testing", "Funcional Testing")]//Preguntar como probar esto
+        [Trait("Level Testing", "Funcional Testing")]
         public void UC4_AF0_UC4_RepairsNotAvailable()
         {
             //Arrange

--- a/test/AppForSEII2526.UIT/UC_Receipt/UC_Receipts_UIT.cs
+++ b/test/AppForSEII2526.UIT/UC_Receipt/UC_Receipts_UIT.cs
@@ -1,4 +1,4 @@
-﻿using AppForMovies.UIT.Shared;
+﻿using AppForSEII2526.UIT.Shared;
 using OpenQA.Selenium.DevTools.V141.DOM;
 using System;
 using System.Collections.Generic;
@@ -11,14 +11,16 @@ namespace AppForSEII2526.UIT.UC_Receipt
     public class UC_Receipts_UIT : UC_UIT
     {
         private SelectRepairs_PO selectRepairs_PO;
-        private const int RepairId1 = 1; 
+        private PostRepairs_PO postRepairs_PO;
+
+        private const int RepairId1 = 1;
         private const string repairName1 = "Cambio pantalla";
         private const string repairScale1 = "Lujo";
         private const string cost1 = "150,00 €";
         private const string description1 = "Sustitución completa de pantalla OLED";
-        
 
-        private const int RepairId2 = 3; 
+
+        private const int RepairId2 = 3;
         private const string repairName2 = "Reparación puerto carga";
         private const string repairScale2 = "Básica";
         private const string cost2 = "45,00 €";
@@ -38,13 +40,14 @@ namespace AppForSEII2526.UIT.UC_Receipt
         public UC_Receipts_UIT(ITestOutputHelper output) : base(output)
         {
             selectRepairs_PO = new SelectRepairs_PO(_driver, _output);
+            postRepairs_PO = new PostRepairs_PO(_driver, output);
         }
         /* Como no va aún el login lo dejo comentado 
         private void Precondition_perform_login() {
             Perform_login("rdiaz@example.com", "Password123!");
         }
         */
-        private void InitialStepsForReceiptUC() 
+        private void InitialStepsForReceiptUC()
         {
             Initial_step_opening_the_web_page();
             //Precondition_perform_login();
@@ -57,20 +60,35 @@ namespace AppForSEII2526.UIT.UC_Receipt
         [InlineData(repairName1, username, name, surname, deliveryAddress, paymentMethod2, modelo)]
         [InlineData(repairName1, username, name, surname, deliveryAddress, paymentMethod3, modelo)]
         [Trait("Level Testing", "Funcional Testing")]
-        public void IC1_CU1_2_3_BasicFlow(string repair, string username, string name , string surname, string deliveryaddress, string paymentmethod, string model) {
+        public void UC4_UC1_2_3_BasicFlow(string repair, string username, string name, string surname, string deliveryaddress, string paymentmethod, string model)
+        {
             InitialStepsForReceiptUC();
 
-            var expectedReceiptItems = new List<string[]> { 
+            var expectedReceiptItems = new List<string[]> {
                 new string[]{ repairName1, repairScale1, cost1, modelo},
             };
 
 
         }
+        [Fact]
+        [Trait("Level Testing", "Funcional Testing")]//Preguntar como probar esto
+        public void UC4_AF0_UC4_RepairsNotAvailable()
+        {
+            //Arrange
+            InitialStepsForReceiptUC();
+            var expectedMessage = "Error fetching repairs. ";
+
+            //Act
+            selectRepairs_PO.SearchRepairs("", "");
+
+            //Assert
+            Assert.True(selectRepairs_PO.CheckMessageErrorNotAviableRepairs(expectedMessage));
+        }
         [Theory]
-        [InlineData(repairName1, repairScale1, cost1, description1,AddToReceipt,"Cambio pan", "")]
-        [InlineData(repairName2, repairScale2,cost2, description2, AddToReceipt, "", "Bá")]
+        [InlineData(repairName1, repairScale1, cost1, description1, AddToReceipt, "Cambio pan", "")]
+        [InlineData(repairName2, repairScale2, cost2, description2, AddToReceipt, "", "Bá")]
         [Trait("Level Testing", "Funcional Testing")]
-        public void UC4_AF1_UC5_6_filtering(string repairName, string repairScale, string RepairCost, string RepairDescription, string AddToReceipt,string filterName, string filterScale) //En el gihub de elena tiene otro nombre pero no sé bien que es. Preguntar a Aurora.
+        public void UC4_AF1_UC5_6_filtering(string repairName, string repairScale, string RepairCost, string RepairDescription, string AddToReceipt, string filterName, string filterScale) //En el gihub de elena tiene otro nombre pero no sé bien que es. Preguntar a Aurora.
         {
             //Arrange
             InitialStepsForReceiptUC();
@@ -81,7 +99,7 @@ namespace AppForSEII2526.UIT.UC_Receipt
             };
             //Act
             Thread.Sleep(4000); //Esperamos a que cargue la página
-            selectRepairs_PO.SearchMovies(filterName, filterScale);
+            selectRepairs_PO.SearchRepairs(filterName, filterScale);
             Thread.Sleep(4000); //Esperamos a que cargue la tabla con los resultados
             //Assert
             Assert.True(selectRepairs_PO.CheckListOfRepairs(expectedRepairs));
@@ -89,17 +107,60 @@ namespace AppForSEII2526.UIT.UC_Receipt
 
         [Fact]
         [Trait("LevelTesting", "Funcional Testing")]
-        public void UC1_AF2_UC1_8_ReceiptNotAvailable() 
+        public void UC4_AF2_UC_7_UpdateShoppingCart()
         {
             //Arrange
             InitialStepsForReceiptUC();
-            
+            var expectedCost = "150";
+
+            //Act
+            selectRepairs_PO.AddRepairToReceipt(repairName1);
+            selectRepairs_PO.AddRepairToReceipt(repairName2);
+            selectRepairs_PO.DoReceipt();
+
+            postRepairs_PO.FillInModelInfo(modelo, repairName1);
+            postRepairs_PO.FillInModelInfo(modelo, repairName2);
+            postRepairs_PO.PressModifyReceipt();
+
+            selectRepairs_PO.RemoveRepairFromReceipt(repairName2);
+            selectRepairs_PO.DoReceipt();
+
+            //Assert
+            Assert.True(postRepairs_PO.CheckTotalPrice(expectedCost));
+        }
+
+        [Fact]
+        [Trait("LevelTesting", "Funcional Testing")]
+        public void UC4_AF3_UC1_8_ReceiptNotAvailable()
+        {
+            //Arrange
+            InitialStepsForReceiptUC();
+
             //Act
             selectRepairs_PO.AddRepairToReceipt(repairName1);
             selectRepairs_PO.RemoveRepairFromReceipt(repairName1);
 
             //Assert
             Assert.True(selectRepairs_PO.ReceiptNotAvaible());
+        }
+        [Theory]
+        [InlineData("", surname, deliveryAddress, paymentMethod2, modelo, "The Username field is required.")]
+        [InlineData(username, "", deliveryAddress, paymentMethod2, modelo, "The Usersurname field is required.")]
+        [InlineData(username, surname, "", paymentMethod2, modelo, "Error en la dirección de envío. Por favor, introduce una dirección válida inluyendo las palabras Calle o Avenida")]
+        [InlineData(username, surname, deliveryAddress, paymentMethod2, "", "The Model field is required.")]
+        [Trait("LevelTesting", "Funcional Testing")]
+        public void UC4_AF4_UC9_10_11_12_ValidationErrors(string name, string surname, string deliveryaddress, string paymentmethod, string model, string expectedError)
+        {
+            //Arrange
+            InitialStepsForReceiptUC();
+            //Act
+            selectRepairs_PO.AddRepairToReceipt(repairName1);
+            selectRepairs_PO.DoReceipt();
+            postRepairs_PO.FillInReceiptInfo(name, surname, deliveryaddress, paymentmethod);
+            postRepairs_PO.FillInModelInfo(model, repairName1);
+            postRepairs_PO.PressSubmitReceipt();
+            //Assert
+            Assert.True(postRepairs_PO.CheckValidationError(expectedError));
         }
     }
 }

--- a/test/AppForSEII2526.UIT/UC_Receipt/UC_Receipts_UIT.cs
+++ b/test/AppForSEII2526.UIT/UC_Receipt/UC_Receipts_UIT.cs
@@ -12,11 +12,14 @@ namespace AppForSEII2526.UIT.UC_Receipt
     {
         private SelectRepairs_PO selectRepairs_PO;
         private PostRepairs_PO postRepairs_PO;
+        private DetailsRepairs_PO detailsRepairs_PO;
 
         private const int RepairId1 = 1;
         private const string repairName1 = "Cambio pantalla";
         private const string repairScale1 = "Lujo";
         private const string cost1 = "150,00 €";
+        private const string cost1NoDecimals = "150 €";
+        private const string cost1Number = "150";
         private const string description1 = "Sustitución completa de pantalla OLED";
 
 
@@ -41,6 +44,7 @@ namespace AppForSEII2526.UIT.UC_Receipt
         {
             selectRepairs_PO = new SelectRepairs_PO(_driver, _output);
             postRepairs_PO = new PostRepairs_PO(_driver, output);
+            detailsRepairs_PO = new DetailsRepairs_PO(_driver, output);
         }
         /* Como no va aún el login lo dejo comentado 
         private void Precondition_perform_login() {
@@ -65,9 +69,20 @@ namespace AppForSEII2526.UIT.UC_Receipt
             InitialStepsForReceiptUC();
 
             var expectedReceiptItems = new List<string[]> {
-                new string[]{ repairName1, repairScale1, cost1, modelo},
+                new string[]{ repairName1, repairScale1, cost1Number, modelo},
             };
 
+            //Act
+            selectRepairs_PO.AddRepairToReceipt(repair);
+            selectRepairs_PO.DoReceipt();
+
+            postRepairs_PO.FillInReceiptInfo(username, (name + " " + surname), deliveryaddress, paymentmethod);
+            postRepairs_PO.FillInModelInfo(model, repair);
+            postRepairs_PO.PressSubmitReceipt();
+            postRepairs_PO.PressOkModalDialog();
+            //Assert
+            Assert.True(detailsRepairs_PO.CheckReceiptDetail(name+" "+surname,deliveryaddress, DateTime.Now, cost1NoDecimals), "Receipt details are not correct");
+            Assert.True(detailsRepairs_PO.CheckListOfDetailsRepairs(expectedReceiptItems), "Receipt items are not correct");
 
         }
         [Fact]
@@ -144,10 +159,10 @@ namespace AppForSEII2526.UIT.UC_Receipt
             Assert.True(selectRepairs_PO.ReceiptNotAvaible());
         }
         [Theory]
-        [InlineData("", surname, deliveryAddress, paymentMethod2, modelo, "The Username field is required.")]
+        [InlineData("", (name + " " + surname), deliveryAddress, paymentMethod2, modelo, "The Username field is required.")]
         [InlineData(username, "", deliveryAddress, paymentMethod2, modelo, "The Usersurname field is required.")]
-        [InlineData(username, surname, "", paymentMethod2, modelo, "Error en la dirección de envío. Por favor, introduce una dirección válida inluyendo las palabras Calle o Avenida")]
-        [InlineData(username, surname, deliveryAddress, paymentMethod2, "", "The Model field is required.")]
+        [InlineData(username, (name + " " + surname), "", paymentMethod2, modelo, "The Userdeliveryaddress field is required.")]
+        [InlineData(username, (name + " " + surname), deliveryAddress, paymentMethod2, "", "The Model field is required.")]
         [Trait("LevelTesting", "Funcional Testing")]
         public void UC4_AF4_UC9_10_11_12_ValidationErrors(string name, string surname, string deliveryaddress, string paymentmethod, string model, string expectedError)
         {
@@ -161,6 +176,34 @@ namespace AppForSEII2526.UIT.UC_Receipt
             postRepairs_PO.PressSubmitReceipt();
             //Assert
             Assert.True(postRepairs_PO.CheckValidationError(expectedError));
+        }
+
+        [Fact]
+        [Trait("LevelTesting", "Funcional Testing")]
+        public void UC4_AF5_UC13_ModifyReceipt() 
+        {
+            InitialStepsForReceiptUC();
+            var expectedReceiptItems = new List<string[]>
+            {
+                new string[] { repairName1, repairScale1, cost1Number},
+            };
+
+            //Act
+            selectRepairs_PO.AddRepairToReceipt(repairName1);
+            selectRepairs_PO.AddRepairToReceipt(repairName2);
+            selectRepairs_PO.DoReceipt();
+
+            postRepairs_PO.FillInModelInfo(modelo, repairName1);
+            postRepairs_PO.FillInModelInfo(modelo, repairName2);
+            postRepairs_PO.FillInReceiptInfo(username, (name + " " + surname), deliveryAddress, paymentMethod2);
+            
+            postRepairs_PO.PressModifyReceipt();
+            selectRepairs_PO.RemoveRepairFromReceipt(repairName2);
+            selectRepairs_PO.DoReceipt();
+
+            //Assert
+            Assert.True(postRepairs_PO.CheckListOfReceiptItems(expectedReceiptItems, modelo, repairName1));
+
         }
     }
 }


### PR DESCRIPTION
- Cambiado nombre que estaba mal en el namespace de UC_UIT
- Pruebas funcionales completadas conforme a los casos de pruebas y funcionando
- Añadido en postrepairs que compruebe que el campo modelo contiene información antes de abrir el dialogo, ya que no se comprobaba de forma correcta a pesar de estar la etiqueta required y provocaba una excepción 